### PR TITLE
Bump pry-doc version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Upgrade [pry-doc][pry-doc] to 1.0.0
+
 ## 2.1.0 (2016-11-19)
 * Remove [pry-remote][pry-remote]
 

--- a/lib/spirit_hands/hirb/fixes/pager.rb
+++ b/lib/spirit_hands/hirb/fixes/pager.rb
@@ -102,13 +102,11 @@ module Hirb
     remove_method :height
     attr_reader :width, :height, :options
 
-    remove_method :initialize
     def initialize(width, height, options={})
       resize(width, height)
       @options = options
     end
 
-    remove_method :pager_command
     def pager_command
       options[:pager_command] || self.class.pager_command
     end

--- a/lib/spirit_hands/version.rb
+++ b/lib/spirit_hands/version.rb
@@ -1,3 +1,3 @@
 module SpiritHands
-  VERSION = '2.1.6'
+  VERSION = '2.1.7'
 end

--- a/lib/spirit_hands/version.rb
+++ b/lib/spirit_hands/version.rb
@@ -1,3 +1,3 @@
 module SpiritHands
-  VERSION = '2.1.7'
+  VERSION = '2.1.8'
 end

--- a/spirit_hands.gemspec
+++ b/spirit_hands.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.0'
   gem.add_runtime_dependency 'pry', '~> 0.10'
   gem.add_runtime_dependency 'pry-rails', '~> 0.3'
-  gem.add_runtime_dependency 'pry-doc', '~> 0.8'
+  gem.add_runtime_dependency 'pry-doc', '>= 0.8', '< 2.0'
   if RUBY_PLATFORM == 'java'
     gem.platform = 'java'
     gem.add_runtime_dependency 'pry-nav', '~> 0.2.4'


### PR DESCRIPTION
Hello, **steakknife**. Thanks for providing such a useful utility.

This small pull request bumps the [`pry-doc`](https://github.com/pry/pry-doc) dependency to [1.0.0](https://github.com/pry/pry-doc/releases/tag/v1.0.0). From my extensive minutes of research, it seems that version 1.0.0 provides support for ruby 2.6, but does not introduce any breaking changes.

**Note 1:** I set updated the version requirements not to `'~> 1.0.0'`, but `'>= 0.8', '< 2.0'`. My rationale for this is to provide support for `~> 1.0`, but not to force `~> 0.8` users to upgrade if they don't need to.

**Note 2:** I cut my own branch off `spirit_hands 2.1.8`, the most recent version available on RubyGems.org, but it seems that a few of your commits in that release haven't made it to `master` yet, so just a heads-up that this branch pulls those commits in as well.

Thanks again!